### PR TITLE
Hotfix to properly copy an object

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -92,15 +92,16 @@ class Logger {
    */
   context(data) {
     // Mask desired properties
-    data = this.maskBlacklistAttributes(data);
+    let newData = this.deepCopy(data);
+    newData = this.maskBlacklistAttributes(newData);
     let result = null;
-    if (Array.isArray(data)) {
+    if (Array.isArray(newData)) {
       result = {};
-      data.forEach((value, index) => {
+      newData.forEach((value, index) => {
         result[`[Log-${index}]`] = this.extractError(value);
       });
     } else {
-      result = {'[Log-0]': data};
+      result = {'[Log-0]': newData};
     }
     return Object.assign({}, result, this.metadata);
   }
@@ -111,6 +112,27 @@ class Logger {
    */
   defaultInternalLogger() {
     return winstonLoggerFactory(this.config);
+  }
+
+  /**
+   * The default logger
+   * @param {Any} object Any kind of type
+   * @return {Any} a copy of the object
+   */
+  deepCopy(object) {
+    if (!object || typeof object !== 'object') {
+      return object;
+    }
+    let copy = {};
+    const keys = Object.keys(object);
+    for (let index in keys) {
+      if (keys[index]) {
+        const key = keys[index];
+        copy[key] = this.deepCopy(object[key]);
+      }
+    }
+
+    return copy;
   }
 
   /**

--- a/tests/app.js
+++ b/tests/app.js
@@ -40,6 +40,6 @@ app.get('/error', (req, res) => {
   res.end('ok from error');
 });
 
-app.listen(15000, () => {
+app.listen(3000, () => {
   console.log('Listening on 3000');
 });

--- a/tests/app.js
+++ b/tests/app.js
@@ -40,6 +40,6 @@ app.get('/error', (req, res) => {
   res.end('ok from error');
 });
 
-app.listen(3000, () => {
+app.listen(15000, () => {
   console.log('Listening on 3000');
 });


### PR DESCRIPTION
Logger was changing the object state after actual log. This fix consists to avoid this change state.